### PR TITLE
Call to pygments with unpacking operator needs a dict

### DIFF
--- a/hyde/ext/templates/jinja.py
+++ b/hyde/ext/templates/jinja.py
@@ -80,7 +80,7 @@ def syntax(env, value, lexer=None, filename=None):
                     lexers.guess_lexer(value))
     settings = {}
     if hasattr(env.config, 'syntax'):
-        settings = getattr(env.config.syntax, 'options', {})
+        settings = dict(getattr(env.config.syntax, 'options', {}))
 
     formatter = formatters.HtmlFormatter(**settings)
     code = pygments.highlight(value, pyg, formatter)


### PR DESCRIPTION
This patch is more of a RFC, because i'm not sure this is the best way to do this :)

The problem is: The Expando always returns Expandos instead of dicts, and the *\* operator needs a dict.

I don't know if there is a magic method the Expando could implement to satisfy the *\* operator, i couldn't find any. Making Expando inherit from dict worked, but broke the rest of hyde ;)

So the working fixes i found where using "**settings.__dict__" which i consider to ugly to be allowed and "dict(settings)", which works for this case, but is not optimal IMHO because "child" dictionaries are still Expandos.

That does not bother the pygment HtmlFormater, because currently all it's parameters are strings, numbers, bools or lists: http://pygments.org/docs/formatters/#formatter-classes
