### PR TITLE
Prevent Unicode errors if a meta key contains non-ascii chars.

### DIFF
--- a/hyde/model.py
+++ b/hyde/model.py
@@ -44,7 +44,7 @@ class Expando(object):
         Sets the expando attribute after
         transforming the value.
         """
-        setattr(self, key, self.transform(value))
+        setattr(self, key.encode('utf-8'), self.transform(value))
 
     def transform(self, primitive):
         """


### PR DESCRIPTION
`setattr` fails otherwise. I think utf-8 is a sensible default, but might not be the desired encoding in exotic projects.

Note to developers: don't forget to decode it back if you want to embed it in Jinja templates.
