### PR TITLE
Add a configuration switch to ignore some files.

### DIFF
--- a/hyde/model.py
+++ b/hyde/model.py
@@ -128,7 +128,8 @@ class Config(Expando):
             media_url='/media',
             base_url="/",
             not_found='404.html',
-            plugins = []
+            plugins = [],
+            ignore = [ "*~", "*.bak" ]
         )
         conf = dict(**default_config)
         self.sitepath = Folder(sitepath)

--- a/hyde/site.py
+++ b/hyde/site.py
@@ -3,6 +3,7 @@
 Parses & holds information about the site to be generated.
 """
 import os
+import fnmatch
 from hyde.exceptions import HydeException
 from hyde.fs import FS, File, Folder
 from hyde.model import Config
@@ -352,6 +353,9 @@ class RootNode(Node):
 
             @walker.file_visitor
             def visit_file(afile):
+                for pattern in self.site.config.ignore:
+                    if fnmatch.fnmatch(afile.name, pattern):
+                        return
                 self.add_resource(afile)
 
 


### PR DESCRIPTION
By default, backup files are ignored and node turned into a node. With this change, we can ignore those backup files. There is a default list and this is user configurable.
