### PR TITLE
Fix plugin chaining.

### DIFF
--- a/hyde/plugin.py
+++ b/hyde/plugin.py
@@ -40,8 +40,9 @@ class PluginProxy(object):
                             #    "\tCalling plugin [%s]",
                             #   plugin.__class__.__name__)
                             function = getattr(plugin, method_name)
-                            res = function(*args)
-                            if res:
+                            newres = function(*args)
+                            if newres:
+                                res = newres
                                 targs = list(args)
                                 last = None
                                 if len(targs):


### PR DESCRIPTION
When the last plugin of a chain was returning None, the whole chain
return None instead of the last non-None result. For example, chain
LessPlugin with UglifyPlugin and you get all your .less files
unprocessed.
