### PR TITLE
Grab dates from git repository

### DIFF
--- a/hyde/ext/plugins/git.py
+++ b/hyde/ext/plugins/git.py
@@ -51,4 +51,4 @@ class GitDatesPlugin(Plugin):
                     resource.meta.created = created
                 if modified == "git":
                     modified = parse(commits[0].strip())
-                    resource.meta.modified = created
+                    resource.meta.modified = modified


### PR DESCRIPTION
Grab creation and modification date from git repository. To use this
plugin, `created` and `modified` meta data should be set to `git`.
They will be replaced by the proper date.

I use `git` command directly because implementing `git log somefile` is a difficult task when using Git bindings. The name of the plugin may be inappropriate if we want to get the author as well.
