### PR TITLE
Combine files when the resource is complete (after templating).

### DIFF
--- a/hyde/ext/plugins/combine.py
+++ b/hyde/ext/plugins/combine.py
@@ -82,7 +82,7 @@ class CombinePlugin(Plugin):
                             "Resource [%s] removed because combined" % r)
                         r.is_processable = False
 
-    def begin_text_resource(self, resource, text):
+    def text_resource_complete(self, resource, text):
         """
         When generating a resource, add combined file if needed.
         """


### PR DESCRIPTION
Templating engine uses a cache that will keep an old version of the
combined files because the main file was not modified.
