### PR TITLE
plugin: fix  argument processing for args with `=`

### DIFF
--- a/hyde/plugin.py
+++ b/hyde/plugin.py
@@ -297,7 +297,7 @@ class CLTransformer(Plugin):
                 param = "%s%s" % (self.option_prefix(descriptive),
                                         descriptive)
                 if descriptive.endswith("="):
-                    param.append(val)
+                    param += val
                     val = None
                 params.append(param)
                 if val:


### PR DESCRIPTION
If an option ends with `=`, the value was incorrectly appended to the
option. `append` is not a valid method for a string.

(Sorry for not having spotted this one earlier)
