### PR TITLE
fs: Don't recurse inside the .hg, .git or .svn directory when building th

### DIFF
--- a/hyde/fs.py
+++ b/hyde/fs.py
@@ -416,6 +416,7 @@ class FolderWalker(FSVisitor):
                 self.visit_complete()
 
         for root, dirs, a_files in os.walk(self.folder.path, followlinks=True):
+            dirs[:] = [d for d in dirs if d not in ('.hg', '.git', '.svn')]
             folder = Folder(root)
             if not __visit_folder__(folder):
                 dirs[:] = []


### PR DESCRIPTION
I put my 'content' directory in another repository than the root one, and I got trouble hyde was also building the content of the .hg directory ...

This patch should probably be made more generic, maybe even by filtering all the directory beginning with "."
