### PR TITLE
Asciidoc support

### DIFF
--- a/hyde/ext/templates/jinja.py
+++ b/hyde/ext/templates/jinja.py
@@ -88,6 +88,25 @@ def xmldatetime(dt):
         zprefix = tz[:3] + ":" + tz[3:]
     return dt.strftime("%Y-%m-%dT%H:%M:%S") + zprefix
 
+@environmentfilter
+def asciidoc(env, value):
+    """
+    (simple) Asciidoc filter
+    """
+    try:
+        from asciidocapi import AsciiDocAPI
+    except ImportError:
+        print u"Requires AsciiDoc library to use AsciiDoc tag."
+        raise
+
+    import StringIO
+    output = value
+
+    asciidoc = AsciiDocAPI()
+    asciidoc.options('--no-header-footer')
+    result = StringIO.StringIO()
+    asciidoc.execute(StringIO.StringIO(output.encode('utf-8')), result, backend='html4')
+    return unicode(result.getvalue(), "utf-8")
 
 @environmentfilter
 def markdown(env, value):
@@ -173,6 +192,31 @@ class Spaceless(Extension):
             return ''
         return re.sub(r'>\s+<', '><', unicode(caller().strip()))
 
+class Asciidoc(Extension):
+    """
+    A wrapper around the asciidoc filter for syntactic sugar.
+    """
+    tags = set(['asciidoc'])
+
+    def parse(self, parser):
+        """
+        Parses the statements and defers to the callback for asciidoc processing.
+        """
+        lineno = parser.stream.next().lineno
+        body = parser.parse_statements(['name:endasciidoc'], drop_needle=True)
+
+        return nodes.CallBlock(
+                    self.call_method('_render_asciidoc'),
+                        [], [], body).set_lineno(lineno)
+
+    def _render_asciidoc(self, caller=None):
+        """
+        Calls the asciidoc filter to transform the output.
+        """
+        if not caller:
+            return ''
+        output = caller().strip()
+        return asciidoc(self.environment, output)
 
 class Markdown(Extension):
     """
@@ -523,6 +567,7 @@ class Jinja2Template(Template):
         default_extensions = [
                 IncludeText,
                 Spaceless,
+                Asciidoc,
                 Markdown,
                 Syntax,
                 Reference,
@@ -571,6 +616,7 @@ class Jinja2Template(Template):
         self.env.globals['full_url'] = full_url
         self.env.globals['engine'] = engine
         self.env.globals['deps'] = {}
+        self.env.filters['asciidoc'] = asciidoc
         self.env.filters['markdown'] = markdown
         self.env.filters['syntax'] = syntax
         self.env.filters['date_format'] = date_format

--- a/hyde/tests/test_jinja2template.py
+++ b/hyde/tests/test_jinja2template.py
@@ -124,6 +124,42 @@ def test_spaceless():
 """
     assert html.strip() == expected.strip()
 
+def test_asciidoc():
+    source = """
+    {%asciidoc%}
+    == Heading 2 ==
+
+    * test1
+    * test2
+    * test3
+    {%endasciidoc%}
+    """
+    t = Jinja2Template(JINJA2.path)
+    t.configure(None)
+    html = t.render(source, {}).strip()
+    expected_output="""
+    <hr>
+    <h2><a name="_heading_2"></a>Heading 2</h2>
+    <ul>
+    <li>
+    <p>
+    test1
+    </p>
+    </li>
+    <li>
+    <p>
+    test2
+    </p>
+    </li>
+    <li>
+    <p>
+    test3
+    </p>
+    </li>
+    </ul>
+    """
+    assert html == expected_output
+
 
 def test_markdown():
     source = """


### PR DESCRIPTION
Hi,

The support of Asciidoc block is gone in the new versions of hyde. This new code is inspired from the code that was present in the version 0.5.3 and the markdown filter already present in the current version. It is a pretty straightforward port of the previous code.

Regards,
Tony
