### PR TITLE
Ability to import extensions from the sitepath

### DIFF
--- a/hyde/loader.py
+++ b/hyde/loader.py
@@ -13,10 +13,15 @@ plugins = {}
 templates = {}
 
 
-def load_python_object(name):
+def load_python_object(name, site=None):
     """
     Loads a python module from string
     """
+
+    if (site!=None):
+         #Inject the site-path into module search-path
+         sys.path.insert(0, site.config.sitepath.fully_expanded_path)
+
     (module_name, _, object_name) = name.rpartition(".")
     if module_name == '':
         (module_name, object_name) = (object_name, module_name)

--- a/hyde/plugin.py
+++ b/hyde/plugin.py
@@ -186,7 +186,7 @@ class Plugin(object):
         Loads plugins based on the configuration. Assigns the plugins to
         'site.plugins'
         """
-        site.plugins = [loader.load_python_object(name)(site)
+        site.plugins = [loader.load_python_object(name, site)(site)
                             for name in site.config.plugins]
 
     @staticmethod

--- a/hyde/publisher.py
+++ b/hyde/publisher.py
@@ -45,5 +45,5 @@ class Publisher(object):
             logger.error(
                 "Publisher type not specified: %s" % publisher)
             raise Exception("Please specify the publisher type in config.")
-        pub_class = load_python_object(settings.type)
+        pub_class = load_python_object(settings.type, site)
         return pub_class(site, settings, message)


### PR DESCRIPTION
When writing own extensions, the only possibility to import them is to add them to the hyde/ext directory. As this directory will be overwritten during updates and could even be not modifiable for a user at all, there should be a possibility to import extensions from the site-directory. This also enables the user to use site-specific extensions.

This patch enables the functionality without breaking any previously written code. 
