### PR TITLE
markdown: allow to specify output format

### DIFF
--- a/hyde/ext/templates/jinja.py
+++ b/hyde/ext/templates/jinja.py
@@ -106,6 +106,8 @@ def markdown(env, value):
         d['extension_configs'] = getattr(env.config.markdown,
                                         'extension_configs',
                                         Expando({})).to_dict()
+        if hasattr(env.config.markdown, 'output_format'):
+            d['output_format'] = env.config.markdown.output_format
     marked = md.Markdown(**d)
 
     return marked.convert(output)


### PR DESCRIPTION
By default, Markdown is building XHTML. If you do an HTML5 website, it
can therefore generate invalid markups (for example `<th />` is not
valid in HTML5). Markdown can be configured with "output_format". This
patch adds this configuration switch to Hyde:

```
markdown:
  extensions:
    - codehilite
    - extra
    - toc
  output_format: html
```
