### PR TITLE
fix a traceback when subprocess command fails

### DIFF
--- a/hyde/plugin.py
+++ b/hyde/plugin.py
@@ -389,7 +389,7 @@ class CLTransformer(Plugin):
             self.logger.debug(
                 "Calling executable [%s] with arguments %s" %
                     (args[0], unicode(args[1:])))
-            subprocess.check_call(args)
+            subprocess.check_output(args)
         except subprocess.CalledProcessError, error:
             self.logger.error(traceback.format_exc())
             self.logger.error(error.output)


### PR DESCRIPTION
Currently results in a traceback when the command fails.

Ideally we should actually log stderr, since in most apps
that's where the errors go when something goes wrong.
