### PR TITLE
handle non-datetime argument in ext.templates.jinja (needed for Vincent Bernat's sitemaps)

### DIFF
--- a/hyde/ext/templates/jinja.py
+++ b/hyde/ext/templates/jinja.py
@@ -91,7 +91,7 @@ def top(iterable, count=3):
     return islice(iterable, stop=count)
 
 def xmldatetime(dt):
-    if not dt:
+    if not isinstance(dt, datetime):
         dt = datetime.now()
     zprefix = "Z"
     tz = dt.strftime("%z")


### PR DESCRIPTION
Hi,

when trying to build Vincent Bernat's website (see https://github.com/vincentbernat/www.luffy.cx), which I'm using as a starting point for my own site, I get the following error:

```
 18:12:39 hyde.engine Error occurred when processing template: [/home/andreas/src/webdev/hilboll.de/content/de/sitemap.xml]
Traceback (most recent call last):
  File "/home/andreas/.virtualenvs/hyde/bin/hyde", line 9, in <module>
    load_entry_point('hyde==0.8.4', 'console_scripts', 'hyde')()
  File "/home/andreas/.virtualenvs/hyde/lib/python2.7/site-packages/hyde/main.py", line 10, in main
    Engine().run()
  File "/home/andreas/.virtualenvs/hyde/lib/python2.7/site-packages/hyde/engine.py", line 39, in run
    super(Engine, self).run(args)
  File "/home/andreas/.virtualenvs/hyde/lib/python2.7/site-packages/commando.py", line 198, in run
    args.run(self, args)
  File "/home/andreas/.virtualenvs/hyde/lib/python2.7/site-packages/hyde/engine.py", line 118, in gen
    gen.generate_all(incremental=incremental)
  File "/home/andreas/.virtualenvs/hyde/lib/python2.7/site-packages/hyde/generator.py", line 205, in generate_all
    self.__generate_node__(self.site.content, incremental)
  File "/home/andreas/.virtualenvs/hyde/lib/python2.7/site-packages/hyde/generator.py", line 303, in __generate_node__
    self.__generate_resource__(resource, incremental)
  File "/home/andreas/.virtualenvs/hyde/lib/python2.7/site-packages/hyde/generator.py", line 323, in __generate_resource__
    context)
  File "/home/andreas/.virtualenvs/hyde/lib/python2.7/site-packages/hyde/ext/templates/jinja.py", line 797, in render_resource
    out = template.render(context)
  File "/home/andreas/lib/python2.6/site-packages/Jinja2-2.6-py2.6.egg/jinja2/environment.py", line 894, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/andreas/src/webdev/hilboll.de/content/de/sitemap.xml", line 1, in top-level template code
    ---
  File "/home/andreas/src/webdev/hilboll.de/layout/sitemap.j2", line 8, in top-level template code
    <lastmod>{{ res.meta.modified|xmldatetime }}</lastmod>
  File "/home/andreas/.virtualenvs/hyde/lib/python2.7/site-packages/hyde/ext/templates/jinja.py", line 94, in xmldatetime
    tz = dt.strftime("%z")
AttributeError: 'str' object has no attribute 'strftime'
```

This can be avoided by the proposed patch.
