### PR TITLE
Git Plugin: Fall back on file mtime/ctime if not tracked by git

### DIFF
--- a/hyde/ext/plugins/git.py
+++ b/hyde/ext/plugins/git.py
@@ -5,8 +5,10 @@ Contains classes and utilities to extract information from git repository
 
 from hyde.plugin import Plugin
 
+import os.path
 import subprocess
 import traceback
+from datetime import datetime
 from dateutil.parser import parse
 
 class GitDatesPlugin(Plugin):
@@ -39,16 +41,25 @@ class GitDatesPlugin(Plugin):
                 try:
                     commits = subprocess.check_output(["git", "log", "--pretty=%ai",
                                                        resource.path]).split("\n")
+                    commits = commits[:-1]
+                    if not commits:
+                        self.logger.warning("No git history for [%s]" % resource)
                 except subprocess.CalledProcessError:
                     self.logger.warning("Unable to get git history for [%s]" % resource)
-                    continue
-                commits = commits[:-1]
-                if not commits:
-                    self.logger.warning("No git history for [%s]" % resource)
-                    continue
+                    commits = None
+
+                # Set the creation and modification dates. If we have no git history,
+                # we fall back on the file's ctime and mtime to avoid hyde to fail
+                # because the attributes contain a string instead of a date.
                 if created == "git":
-                    created = parse(commits[-1].strip())
+                    if commits:
+                        created = parse(commits[-1].strip())
+                    else:
+                        created = datetime.fromtimestamp(os.path.getctime(resource.path))
                     resource.meta.created = created
                 if modified == "git":
-                    modified = parse(commits[0].strip())
+                    if commits:
+                        modified = parse(commits[0].strip())
+                    else:
+                        modified = datetime.fromtimestamp(os.path.getmtime(resource.path))
                     resource.meta.modified = modified


### PR DESCRIPTION
When using 'git' as the value for resource.meta.created or
resource.meta.modified, the Git plugin will fetch those from the git
repository. But if the file was not known by git, it used to no alter
the attributes, leaving them as the 'git' string.

This was causing issues because many consumers of those attributes
(for instance, the xmldatetime template filter from jinja2) expect to
find a datetime instance and will raise an exception if they find a
string.

This patch works around this issue by falling back on the file's own
ctime and mtime in case the file wasn't added to the git repository yet
(which can happen for brand new entries).
