### PR TITLE
Fix generation of atom.xml in the basic layout.

### DIFF
--- a/hyde/layouts/basic/layout/atom.j2
+++ b/hyde/layouts/basic/layout/atom.j2
@@ -34,7 +34,7 @@
             {% endfor %}
 
             <content type="html">
-                {% refer to res.url as article -%}
+                {% refer to res.relative_deploy_path as article -%}
                 {% filter forceescape -%}
                 {% if resource.meta.excerpts_only -%}
                 {{ article.image|markdown|typogrify }}

--- a/hyde/layouts/basic/layout/macros.j2
+++ b/hyde/layouts/basic/layout/macros.j2
@@ -1,5 +1,5 @@
 {% macro render_excerpt(res, class=None) %}
-{% refer to res.url as post %}
+{% refer to res.relative_deploy_path as post %}
 <article {{'class='~class if class }}>
 <h3><a href="{{ content_url(res.url) }}">{{ res.meta.title }}</a></h3>
 <a href="{{ content_url(res.url) }}">{{ post.image|markdown|typogrify }}</a>


### PR DESCRIPTION
When using 'resource.url' as the argument for the {% refer %} jinja2
tag, hyde fails to find the resource because since the url starts with a
'/', it is considered as an absolute path by the hyde FS abstraction.
This results in an empty content in the atom feed.

Using resource.relative_deploy_path solves the issue, as it is basically
the same as the url without the initial '/'.
