### PR TITLE
Added encoding safe list config value 

### DIFF
--- a/hyde/model.py
+++ b/hyde/model.py
@@ -155,6 +155,7 @@ class Config(Expando):
             layout_root='layout',
             media_url='/media',
             base_url="/",
+            encode_safe=None,
             not_found='404.html',
             plugins = [],
             ignore = [ "*~", "*.bak", ".hg", ".git", ".svn"],

--- a/hyde/site.py
+++ b/hyde/site.py
@@ -425,6 +425,8 @@ class Site(object):
                         .replace(os.sep, '/').encode("utf-8")
         if safe is not None:
             return quote(fpath, safe)
+        elif self.config.encode_safe is not None:
+            return quote(fpath, self.config.encode_safe)
         else:
             return quote(fpath)
 
@@ -438,6 +440,8 @@ class Site(object):
                         .replace(os.sep, '/').encode("utf-8")
         if safe is not None:
             return quote(fpath, safe)
+        elif self.config.encode_safe is not None:
+            return quote(fpath, self.config.encode_safe)
         else:
             return quote(fpath)
 
@@ -447,6 +451,9 @@ class Site(object):
         configuration and returns the appropriate url. The return value
         is url encoded.
         """
+        if safe is None and self.config.encode_safe is not None:
+            safe = self.config.encode_safe
+            
         if urlparse.urlparse(path)[:2] != ("",""):
             return path
         if self.is_media(path):


### PR DESCRIPTION
Added config value to allow user-defined encode safe list to be used with the encoding of url values (media_url, content_url, and full_url). I wanted to use absolute urls for the media_url config value (without encoding the : and /) and did not want to add a safe parameter to every media_url() call.
