### PR TITLE
python 2.6 and plugins 

### DIFF
--- a/hyde/plugin.py
+++ b/hyde/plugin.py
@@ -391,7 +391,7 @@ class CLTransformer(Plugin):
                     (args[0], unicode(args[1:])))
             try:
                 subprocess.check_output(args)
-            except NameError:
+            except AttributeError:
                 # prior python 2.7 there is no ``check_output``
                 self.logger.debug("output: %s", 
                         subprocess.Popen(args, 


### PR DESCRIPTION
hey guys, 

there is a bug when using python 2.6. `submodule.check_output` is only available since 2.7. 

this patch is working well for me, would be cool if you can pull it :)

andi
