### PR TITLE
Fixing the .clear styleName to be .clearfix instead.  

### DIFF
--- a/hyde/layouts/basic/content/media/css/site.css
+++ b/hyde/layouts/basic/content/media/css/site.css
@@ -28,7 +28,7 @@ table {
 }
 
 /* clearfix */
-.clear:after {
+.clearfix:after {
     content: ".";
     display: block;
     clear: both;
@@ -37,12 +37,12 @@ table {
     height: 0;
 }
 
-.clear {
+.clearfix {
     display: block;
 }
 
 
-* html .clear {
+* html .clearfix {
     height: 1%;
 }
 


### PR DESCRIPTION
Base.j2 applies the 'clearfix' class to the 'banner' element, and not the 'clear' class. 

Discovered after inserting relatively position as opposed to absolutely position children into banner, floated left, and noting clearfix wasn't being properly applied to grow the height of the banner element to its children. We _could_ also change the class applied to the banner to be 'clear' instead of 'clearfix', but I'd rather go with the former.
