### PR TITLE
Fix case where markdown parser incorrectly run over code blocks

### DIFF
--- a/hyde/ext/templates/jinja.py
+++ b/hyde/ext/templates/jinja.py
@@ -192,9 +192,9 @@ def syntax(env, value, lexer=None, filename=None):
     caption = filename if filename else pyg.name
     if hasattr(env.config, 'syntax'):
         if not getattr(env.config.syntax, 'use_figure', True):
-            return Markup(code)
+            return Markup('\n' + code)
     return Markup(
-            '<div class="codebox"><figure class="code">%s<figcaption>%s</figcaption></figure></div>\n\n'
+            '\n<div class="codebox"><figure class="code">%s<figcaption>%s</figcaption></figure></div>\n\n'
                         % (code, caption))
 
 class Spaceless(Extension):


### PR DESCRIPTION
Added leading new line to HTML before running through syntax highlighting. 

Without this the div block can on the next line to normal text, which means that it isn't treated as a HTML block by the markdown parser, which means the markdown parser will parse the contents of the <span> tags and corrupt the code. This means that \* symbols are replaced with em tags in code.
