### PR TITLE
Update hyde/layouts/basic/layout/atom.j2

### DIFF
--- a/hyde/layouts/basic/layout/atom.j2
+++ b/hyde/layouts/basic/layout/atom.j2
@@ -34,7 +34,7 @@
             {% endfor %}
 
             <content type="html">
-                {% refer to res.url as article -%}
+                {% refer to res.relative_path as article -%}
                 {% filter forceescape -%}
                 {% if resource.meta.excerpts_only -%}
                 {{ article.image|markdown|typogrify }}


### PR DESCRIPTION
Fix to the atom.j2 layout to keep the article 'resource' scope, thus fixing some issues that may occur if you had references to the 'resource' variable within the article content.
