### PR TITLE
restructuredtext plugin support

### DIFF
--- a/hyde/ext/templates/jinja.py
+++ b/hyde/ext/templates/jinja.py
@@ -160,6 +160,11 @@ def restructuredtext(env, value):
     highlight_source = False
     if hasattr(env.config, 'restructuredtext'):
         highlight_source = getattr(env.config.restructuredtext, 'highlight_source', False)
+        extensions = getattr(env.config.restructuredtext, 'extensions', [])
+        import imp
+        for extension in extensions:
+            imp.load_module(extension, *imp.find_module(extension))
+
 
     if highlight_source:
         import hyde.lib.pygments.rst_directive


### PR DESCRIPTION
I've added a feature to match the markdown extension support. Now in site.yaml, you can have

```
restructuredtext:
    extensions:
         - mylib.my_rst_extension
```

the extensions list is an import path to the module containing the extension (similar to the pattern for jinja and markdown extensions)
