### PR TITLE
Whitespace in menu

### DIFF
--- a/hyde/layouts/starter/layout/macros.j2
+++ b/hyde/layouts/starter/layout/macros.j2
@@ -4,7 +4,7 @@
 {% macro render_basic_menu() -%}
 <ul class="basic">
 {% for menu_item in menu -%}
-    <li><a {% if (menu_item.url == resource.url) %}class="selected"{% endif -%}
+    <li><a {% if (menu_item.url == resource.url) %}class="selected" {% endif -%}
         href="{{ content_url(menu_item.url) }}">{{ menu_item.title }}</a></li>
 {%- endfor %}
 </ul>
@@ -18,7 +18,7 @@
 {% macro render_advanced_menu() -%}
 <ul class="advanced">
 {% for res in site.content.walk_resources_sorted_by_index() %}
-    <li><a {% if (res.url == resource.url) %}class="selected"{% endif -%}
+    <li><a {% if (res.url == resource.url) %}class="selected" {% endif -%}
         href="{{ res.full_url }}">{{ res.meta.title }}
         </a></li>
 {% endfor %}


### PR DESCRIPTION
hyde produced unclean HTML like
`<a class="selected"href="/page">`

This fix adds the white space, which results in
`<a class="selected" href="/page">`
