### PR TITLE
Make username optionnal in ssh publisher (FIX)

### DIFF
--- a/hyde/ext/publishers/ssh.py
+++ b/hyde/ext/publishers/ssh.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 class SSH(Publisher):
     def initialize(self, settings):
         self.settings = settings
-        self.username = settings.username
+        self.username = settings.username if hasattr(settings, 'username') else ''
         self.server = settings.server
         self.target = settings.target
         self.command = getattr(settings, 'command', 'rsync')


### PR DESCRIPTION
The patch submitted in https://github.com/hyde/hyde/pull/222 was not enough to fix the problem. This patch fix the forgotten line. 

I apologize for the inconvenience. This one has been tested.
