### PR TITLE
Fix setting of query in HtmlWrap class based on availability of PyQuery

### DIFF
--- a/hyde/template.py
+++ b/hyde/template.py
@@ -24,9 +24,8 @@ class HtmlWrap(object):
         try:
             from pyquery import PyQuery
         except:
-            PyQuery = False
-        if PyQuery:
-            self.q = PyQuery(html)
+            PyQuery = None
+        self.q = PyQuery(html) if PyQuery else None
 
     def __unicode__(self):
         return self.raw


### PR DESCRIPTION
If PyQuery isn't available, it just doesn't set self.q
and later, when it is accessed in `__call__`, it throws
an exception. The solution is to set it to None if PyQuery
isn't available.