### PR TITLE
Let ImageSizerPlugin find thumbnails generated by ImageThumbnailsPlugin

### DIFF
--- a/hyde/ext/plugins/images.py
+++ b/hyde/ext/plugins/images.py
@@ -63,6 +63,12 @@ class ImageSizerPlugin(PILPlugin):
                 path = src[len(self.site.config.media_url):].lstrip("/")
                 path = self.site.config.media_root_path.child(path)
                 image = self.site.content.resource_from_relative_deploy_path(path)
+                if image is None:
+                    # Handle the case where the referenced image was generated
+                    # by ImageThumbnailsPlugin by checking if the given image
+                    # path matches such a thumbnail
+                    path = os.path.join(".thumbnails", src.lstrip("/"))
+                    image = self.site.content.resource_from_relative_path(path)
             elif re.match(r'([a-z]+://|//).*', src):
                 # Not a local link
                 return ""       # Nothing


### PR DESCRIPTION
**Problem:** If one generates thumbnails with `ImageThumbnailsPlugin` from e.g. images in `content/media/images`, the resulting thumbnails are placed in the directory `content/.thumbnails/media/images` with the given thumbnail prefix prepended to the file name. The thumbnails are supposed to be linked in the HTML documents as if they still were in the same directory as the original image, though. The rationale for this is given in the source as:

```
# Prepare path, make all thumnails in single place(content/.thumbnails)
# for simple maintenance but keep original deploy path to preserve
# naming logic in generated site
```

So, when including e.g. `images/thumb_myimage.jpg` in the document, `ImageSizerPlugin` will look at the HTML document, find this path, discover that it does not correspond to a physical file on disk and continue without other action than a warning message: `[resource] has an unknown image`.

**Solution:** I added an extra path check that should find these thumbnails. It works in my test site, at least, with all path definitions at default.

The `.thumbnails/` path is hardcoded, which is not ideal, but it is the way it is currently solved in `ImageThumbnailsPlugin` as well. I can think of other solutions, but this is probably the one that requires the least effort and reorganization.
