### PR TITLE
utf8 charset header was missing in basic layout 

### DIFF
--- a/hyde/layouts/basic/layout/base.j2
+++ b/hyde/layouts/basic/layout/base.j2
@@ -29,6 +29,7 @@
 
   <!--  Mobile viewport optimized: j.mp/bplateviewport -->
   <meta name="viewport" content="{{ resource.meta.viewport }}">
+  <meta charset="utf-8" />
 
   {% block favicons %}
   <!-- Place favicon.ico & apple-touch-icon.png


### PR DESCRIPTION
the meta tag for charset is missing in "basic" layout but included in "starter" layout.

I just added  utf8 charset to hyde/layouts/basic/layout/base.j2  