### PR TITLE
New pep8 rules cleanup

### DIFF
--- a/hyde/ext/plugins/structure.py
+++ b/hyde/ext/plugins/structure.py
@@ -338,8 +338,8 @@ class PaginatorPlugin(Plugin):
         for node in self.site.content.walk():
             added_resources = []
             paged_resources = (res for res in node.resources
-                               if hasattr(res, "meta")
-                               and hasattr(res.meta, 'paginator'))
+                               if hasattr(res, "meta") and
+                               hasattr(res.meta, 'paginator'))
             for resource in paged_resources:
                 paginator = Paginator(resource.meta.paginator)
                 added_resources += paginator.walk_paged_resources(

--- a/hyde/lib/pygments/rst_directive.py
+++ b/hyde/lib/pygments/rst_directive.py
@@ -35,13 +35,18 @@
     :license: BSD, see LICENSE for details.
 """
 
+from docutils import nodes
+from docutils.parsers.rst import directives, Directive
+
+from pygments import highlight
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import get_lexer_by_name, TextLexer
+
 # Options
 # ~~~~~~~
 
 # Set to True if you want inline CSS styles instead of classes
 INLINESTYLES = False
-
-from pygments.formatters import HtmlFormatter
 
 # The default formatter
 DEFAULT = HtmlFormatter(noclasses=INLINESTYLES)
@@ -50,13 +55,6 @@ DEFAULT = HtmlFormatter(noclasses=INLINESTYLES)
 VARIANTS = {
     'linenos': HtmlFormatter(noclasses=INLINESTYLES, linenos=True),
 }
-
-
-from docutils import nodes
-from docutils.parsers.rst import directives, Directive
-
-from pygments import highlight
-from pygments.lexers import get_lexer_by_name, TextLexer
 
 
 class Pygments(Directive):


### PR DESCRIPTION
This was originally included in #307, but it makes much more sense as its own PR. These changes don't depend on Python 3 support, and that shouldn't hold back the build status of other branches or pull requests.