### PR TITLE
Add coverage to tox

### DIFF
--- a/dev-only.txt
+++ b/dev-only.txt
@@ -1,3 +1,4 @@
+coverage>=4.0.3, <5.0
 pyquery>=1.2.9, <2.0
 docutils>=0.12, <1.0
 mock>=1.0.1, <2.0

--- a/hyde/_compat.py
+++ b/hyde/_compat.py
@@ -12,7 +12,9 @@ PY3 = sys.version_info.major == 3
 if PY3:
     # Imports that have moved.
     from collections import UserDict  # NOQA
+    import configparser  # NOQA
     from functools import reduce  # NOQA
+    from http.client import HTTPConnection, HTTPSConnection  # NOQA
     from http.server import HTTPServer, SimpleHTTPRequestHandler  # NOQA
     from io import StringIO  # NOQA
     from urllib import parse  # NOQA
@@ -43,7 +45,9 @@ if PY3:
 else:
     # Imports that have moved.
     from itertools import ifilter as filter, izip as zip  # NOQA
+    import ConfigParser as configparser  # NOQA
     reduce = reduce
+    from httplib import HTTPConnection, HTTPSConnection  # NOQA
     from BaseHTTPServer import HTTPServer  # NOQA
     from SimpleHTTPServer import SimpleHTTPRequestHandler  # NOQA
     from cStringIO import StringIO  # NOQA

--- a/hyde/ext/publishers/pypi.py
+++ b/hyde/ext/publishers/pypi.py
@@ -8,12 +8,10 @@ import os
 import getpass
 import zipfile
 import tempfile
-import httplib
-import urlparse
 from base64 import standard_b64encode
-import ConfigParser
 
-from hyde._compat import input
+from hyde._compat import (configparser, input, HTTPConnection, HTTPSConnection,
+                          parse)
 from hyde.publisher import Publisher
 
 from commando.util import getLoggerWithNullHandler
@@ -35,10 +33,10 @@ class PyPI(Publisher):
         if not os.path.isfile(pypirc_file):
             pypirc = None
         else:
-            pypirc = ConfigParser.RawConfigParser()
+            pypirc = configparser.Rawconfigparser()
             pypirc.read([pypirc_file])
         missing_errs = (
-            ConfigParser.NoSectionError, ConfigParser.NoOptionError)
+            configparser.NoSectionError, configparser.NoOptionError)
         #  Try to find username in .pypirc
         if self.username is None:
             if pypirc is not None:
@@ -104,11 +102,11 @@ class PyPI(Publisher):
             content_length = len(body_prefix) + tf.tell() + len(body_suffix)
             #  POST it up to PyPI
             logger.info("uploading to PyPI")
-            url = urlparse.urlparse(self.url)
+            url = parse.urlparse(self.url)
             if url.scheme == "https":
-                con = httplib.HTTPSConnection(url.netloc)
+                con = HTTPSConnection(url.netloc)
             else:
-                con = httplib.HTTPConnection(url.netloc)
+                con = HTTPConnection(url.netloc)
             con.connect()
             try:
                 con.putrequest("POST", self.url)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ sitepackages = True
 # Needed for asciidoc
 passenv = PYTHONPATH
 deps = -r{toxinidir}/dev-req.txt
-commands = nosetests {posargs}
+commands = nosetests --with-coverage --cover-package=hyde --cover-erase {posargs}
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
Add the ``coverage`` plugin to ``nosetests`` commands run by ``tox``.
References #277. Additionally, add a few more compatibility imports.