### PR TITLE
Fixed issue with simple_copy (related to issue #121)

### DIFF
--- a/hyde/generator.py
+++ b/hyde/generator.py
@@ -149,7 +149,7 @@ class Generator(object):
                             dep_res.relative_path].append(rel_path)
                     else:
                         deps.extend(self.get_dependencies(dep_res))
-        if resource.uses_template:
+        if resource.uses_template and not resource.simple_copy:
             deps.extend(self.template.get_dependencies(rel_path))
         deps = list(set(deps))
         if None in deps:


### PR DESCRIPTION
In hyde 0.8.9, when marking text files for simple copying, as in:

    simple_copy:
        - media/**/*.js
        - "**/*.ppm"
        - "**/*.htm"

Following exceptions are raised on (re)generation:

**"pure" HTML file** (in ISO8859-1, French):

     21:35:19 hyde Unicode error when processing archive/05-06/article-02.htm
    Traceback (most recent call last):
      File "/home/ales/bin/hyde", line 9, in <module>
        load_entry_point('hyde==0.8.9', 'console_scripts', 'hyde')()
      File "/usr/lib/python2.7/site-packages/hyde/main.py", line 11, in main
        Engine().run()
      File "/usr/lib/python2.7/site-packages/commando/application.py", line 309, in run
        args.run(self, args)
      File "/usr/lib/python2.7/site-packages/hyde/engine.py", line 102, in gen
        gen.generate_all(incremental=incremental)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 216, in generate_all
        self.__generate_node__(self.site.content, incremental)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 313, in __generate_node__
        self.__generate_resource__(resource, incremental)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 321, in __generate_resource__
        if incremental and not self.has_resource_changed(resource):
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 184, in has_resource_changed
        deps = self.get_dependencies(resource)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 129, in get_dependencies
        else self.update_deps(resource)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 153, in update_deps
        deps.extend(self.template.get_dependencies(rel_path))
      File "/usr/lib/python2.7/site-packages/hyde/ext/templates/jinja.py", line 799, in get_dependencies
        text = self.env.loader.get_source(self.env, path)[0]
      File "/usr/lib/python2.7/site-packages/hyde/ext/templates/jinja.py", line 652, in get_source
        "Unicode error when processing %s" % template, sys.exc_info())
      File "/usr/lib/python2.7/site-packages/hyde/ext/templates/jinja.py", line 649, in get_source
        environment, template)
      File "/usr/lib/python2.7/site-packages/jinja2/loaders.py", line 175, in get_source
        contents = f.read().decode(self.encoding)
      File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
        return codecs.utf_8_decode(input, errors, True)
    hyde.exceptions.HydeException: Unicode error when processing archive/05-06/article-02.htm

**Minified javascript** (`{{` sequence detected as Jinja directive):

     21:39:46 hyde Error processing media/lightbox/js/lightbox.min.js:
    expected token 'end of print statement', got 'a'
    Traceback (most recent call last):
      File "/home/ales/bin/hyde", line 9, in <module>
        load_entry_point('hyde==0.8.9', 'console_scripts', 'hyde')()
      File "/usr/lib/python2.7/site-packages/hyde/main.py", line 11, in main
        Engine().run()
      File "/usr/lib/python2.7/site-packages/commando/application.py", line 309, in run
        args.run(self, args)
      File "/usr/lib/python2.7/site-packages/hyde/engine.py", line 102, in gen
        gen.generate_all(incremental=incremental)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 216, in generate_all
        self.__generate_node__(self.site.content, incremental)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 313, in __generate_node__
        self.__generate_resource__(resource, incremental)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 321, in __generate_resource__
        if incremental and not self.has_resource_changed(resource):
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 184, in has_resource_changed
        deps = self.get_dependencies(resource)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 129, in get_dependencies
        else self.update_deps(resource)
      File "/usr/lib/python2.7/site-packages/hyde/generator.py", line 153, in update_deps
        deps.extend(self.template.get_dependencies(rel_path))
      File "/usr/lib/python2.7/site-packages/hyde/ext/templates/jinja.py", line 806, in get_dependencies
        sys.exc_info())
      File "/usr/lib/python2.7/site-packages/hyde/ext/templates/jinja.py", line 802, in get_dependencies
        ast = self.env.parse(text)
      File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 466, in parse
        self.handle_exception(exc_info, source_hint=source)
      File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
        reraise(exc_type, exc_value, tb)
      File "<unknown>", line 9, in template
    hyde.exceptions.HydeException: Error processing media/lightbox/js/lightbox.min.js:
    expected token 'end of print statement', got 'a'