### PR TITLE
Fix TypeError in `vcs.py` which affects only python3

### DIFF
--- a/hyde/ext/plugins/vcs.py
+++ b/hyde/ext/plugins/vcs.py
@@ -79,7 +79,7 @@ class GitDatesPlugin(VCSDatesPlugin):
                 "log",
                 "--pretty=%ai",
                 resource.path
-            ]).split("\n")
+            ]).split(b"\n")
             commits = commits[:-1]
         except subprocess.CalledProcessError:
             self.logger.warning(


### PR DESCRIPTION
In Python3 `subprocess.check_output(<...>)` returns a byte sequence. In this
case the argument to method `split` must also be of byte type.

This commit fixes a tiny error in `vcs.py` and ensures plugin GitDates is
available under python2 as well as python3.