### PR TITLE
Fixed base exception error after install on python3.8

### DIFF
--- a/hyde/exceptions.py
+++ b/hyde/exceptions.py
@@ -1,10 +1,14 @@
-from hyde._compat import reraise
-
-
 class HydeException(Exception):
     """Base class for exceptions from hyde."""
 
-    @staticmethod
-    def reraise(message, exc_info):
-        _, _, tb = exc_info
-        reraise(HydeException, HydeException(message), tb)
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = None
+    def __repr__(self):
+        """What is printed if something goes wrong"""
+        if self.message:
+            return "Exception raised: {}".format(self.message)
+        else:
+            return "Unlucky there bud"


### PR DESCRIPTION
This resolves the issue outlined in https://github.com/hyde/hyde/issues/326

I couldn't run the tests locally on any of my machines to validate the fix