### PR TITLE
GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature]"
+labels: enhancement
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,24 @@
+---
+name: question
+about: Submit a question to help us improve
+title: "[question]"
+labels: documentation
+
+---
+
+**Question**
+Add your question here
+
+
+**Expected behavior**
+If what happened was unexpected, outline the expected behaviour.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Ubuntu]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,65 @@
+*Go through and fill out either the feature request, or bug fix sections and delete the other. Then check off the checklist and submit.*
+
+# Feature request
+*Fill out below fields*
+
+Issue number : *add reference to issue number (if applicable)*
+
+If you filled out the issue number move on to the checklist sectionm if not fill in these deatils:
+
+**Description of functionality**
+*Add a bit of infomation about what you intend for this feature to do*
+
+**Current behaviour**
+A clear and concise description of what currently happens.
+
+**Desired behavior**
+A clear and concise description of what you want to happen.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Version [e.g. 22]
+
+---
+
+# Bug Fix
+
+## Details
+
+*Fill out below fields*
+
+Issue number : *add reference to issue number (if applicable)*
+
+If you filled out the issue number move on to the checklist sectionm if not fill in these deatils:
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Current behaviour**
+A clear and concise description of what currently happens.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Version [e.g. 22]
+
+---
+
+# Checklist
+
+- [ ] Commenting is present in all Classes, modules, and functions.
+- [ ] Validated this change does not break backwards compatibility without good reason
+- [ ] Existing Tests all pass
+- [ ] New tests have been added to verify any new functionality / issue
+- [ ] Changelog up to date
+- [ ] Version up to date
+- [ ] Authors list up to date

--- a/hyde/exceptions.py
+++ b/hyde/exceptions.py
@@ -1,10 +1,14 @@
-from hyde._compat import reraise
-
-
 class HydeException(Exception):
     """Base class for exceptions from hyde."""
 
-    @staticmethod
-    def reraise(message, exc_info):
-        _, _, tb = exc_info
-        reraise(HydeException, HydeException(message), tb)
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = None
+    def __repr__(self):
+        """What is printed if something goes wrong"""
+        if self.message:
+            return "Exception raised: {}".format(self.message)
+        else:
+            return "Unlucky there bud"


### PR DESCRIPTION
I added some github templates that might make creating PR's and issues simpler, I just added some pretty generic ones that can be modified to better suit needs. You can see examples of how they work here: https://github.com/canadian-coding/python-package-template/issues/new/choose


Also I accidentally added #327 to my master so it's included in this PR, for some reason the pipeline is failing on dependency installation so I can't validate it through the current travis build. If anyone has suggestions so I can validate #327 I would appreciate it.