### PR TITLE
docs: fix simple typo, utiltities -> utilities

### DIFF
--- a/hyde/plugin.py
+++ b/hyde/plugin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Contains definition for a plugin protocol and other utiltities.
+Contains definition for a plugin protocol and other utilities.
 """
 from hyde._compat import str
 from hyde.exceptions import HydeException


### PR DESCRIPTION
There is a small typo in hyde/plugin.py.

Should read `utilities` rather than `utiltities`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md