### PR TITLE
dont convert to rgba if jpeg, addresses #348

### DIFF
--- a/hyde/ext/plugins/images.py
+++ b/hyde/ext/plugins/images.py
@@ -291,9 +291,12 @@ class ImageThumbnailsPlugin(PILPlugin):
         self.logger.debug("Making thumbnail for [%s]" % resource)
 
         im = self.Image.open(resource.path)
-        if im.mode != 'RGBA':
-            im = im.convert('RGBA')
         format = im.format
+        # don't convert JPEG to RGBA because PIL doesn't
+        # support saving JPEGs as that from v 3.7
+        # see https://github.com/python-pillow/Pillow/commit/193c7561392fd12c3bd93bc232d9041c89bec4f6
+        if im.mode != 'RGBA' and im.format != 'JPEG':
+            im = im.convert('RGBA')
 
         if preserve_orientation and im.size[1] > im.size[0]:
             width, height = height, width


### PR DESCRIPTION
The image plugin thumbnailer generates an error when converting JPEG to thumbnails, since it uses image mode RGBA, and as of about version 3 of Pillow this has been deprecated and then removed. 

This patch tests if the image is a JPEG by checking the `im.format` and does no conversion if its a JPEG.

